### PR TITLE
Added customizable probe command for button in tool change dialog.

### DIFF
--- a/auto-generated-widget.html
+++ b/auto-generated-widget.html
@@ -687,9 +687,19 @@ cpdefine("inline:com-chilipeppr-widget-gcode", ["chilipeppr_ready", "waypoints",
                     if (!('addlinenums' in options))
                         options.addlinenums = true;
                 }
+                // Default new options for backwards compatibility
+                if (!('sendOnM6' in options)) {
+                    options.sendOnM6 = "";
+                }
+                if (!('sendOffM6' in options)) {
+                    options.sendOffM6 = "";
+                }
+                if (!('probeCmd' in options)) {
+                    options.probeCmd = "G28.2 Z0";
+                }
                 
             } else {
-                options = {whenPlay: "serial", perRow: "3d", perRow3dType: "goto", delayPerLine: this.delayPerLine, pauseOnM6: true, preUpload: 'none', multiLineMode: 'yes', multiLines: 50, ppsOnPlayFlush: false, ppsOnStopFeedhold: false, ppsOnPauseFeedhold: false, ppsOnUnpauseResume: false, removeemptylines: true, addlinenums: true};
+                options = {whenPlay: "serial", perRow: "3d", perRow3dType: "goto", delayPerLine: this.delayPerLine, pauseOnM6: true, preUpload: 'none', multiLineMode: 'yes', multiLines: 50, ppsOnPlayFlush: false, ppsOnStopFeedhold: false, ppsOnPauseFeedhold: false, ppsOnUnpauseResume: false, removeemptylines: true, addlinenums: true, sendOnM6: "", sendOffM6: "", probeCmd: "G28.2 Z0"};
             }
             this.options = options;
             console.log("options:", options);
@@ -3979,7 +3989,7 @@ cpdefine("inline:com-chilipeppr-widget-gcode", ["chilipeppr_ready", "waypoints",
                         </div>
                          <p style="padding-top:6px;">Definition of G-code to send as probe command in tool change dialog:</p>
                         <div class="input-group" style="width:300px;">
-                            <textarea class="form-control" id="com-chilipeppr-widget-gcode-option-probe-cmd" placeholder="Gcode"></textarea>
+                            <textarea class="form-control" id="com-chilipeppr-widget-gcode-option-probe-cmd" placeholder="Gcode">G28.2 Z0</textarea>
                         </div>
 
                         <p class="options-heading" style="padding-top:16px;">Pre-Process Gcode</p>

--- a/auto-generated-widget.html
+++ b/auto-generated-widget.html
@@ -714,6 +714,7 @@ cpdefine("inline:com-chilipeppr-widget-gcode", ["chilipeppr_ready", "waypoints",
             }
             $('#com-chilipeppr-widget-gcode-option-sendonM6').val(this.options.sendOnM6);
             $('#com-chilipeppr-widget-gcode-option-sendoffM6').val(this.options.sendOffM6);
+            $('#com-chilipeppr-widget-gcode-option-probe-cmd').val(this.options.probeCmd);
 
             if (this.options.preUpload) {
                 var opt = ["none", "100", "1000", "10000", "20000"];
@@ -805,7 +806,7 @@ cpdefine("inline:com-chilipeppr-widget-gcode", ["chilipeppr_ready", "waypoints",
             var that = this;
             console.log("saveOptionsModal");
 
-            var whenPlay, perRow, perRow3dType, delayPerLine, pauseOnM6, sendOnM6, sendOffM6, showBody, preUpload, multiLineMode, multiLines, ppsOnPlayFlush, ppsOnStopFeedhold, ppsOnPauseFeedhold, ppsOnUnpauseResume, removeemptylines, addlinenums;
+            var whenPlay, perRow, perRow3dType, delayPerLine, pauseOnM6, sendOnM6, sendOffM6, probeCmd, showBody, preUpload, multiLineMode, multiLines, ppsOnPlayFlush, ppsOnStopFeedhold, ppsOnPauseFeedhold, ppsOnUnpauseResume, removeemptylines, addlinenums;
             if ($('#com-chilipeppr-widget-gcode-option-whenplay-serial').is(':checked'))
                 whenPlay = "serial";
             else if ($('#com-chilipeppr-widget-gcode-option-whenplay-3d').is(':checked'))
@@ -824,6 +825,8 @@ cpdefine("inline:com-chilipeppr-widget-gcode", ["chilipeppr_ready", "waypoints",
                 pauseOnM6 = false;
             sendOnM6 = $('#com-chilipeppr-widget-gcode-option-sendonM6').val();
             sendOffM6 = $('#com-chilipeppr-widget-gcode-option-sendoffM6').val();
+            probeCmd = $('#com-chilipeppr-widget-gcode-option-probe-cmd').val();
+        
             if ($('#com-chilipeppr-widget-gcode-option-removeemptylines').is(':checked'))
                 removeemptylines = true;
             else
@@ -866,6 +869,7 @@ cpdefine("inline:com-chilipeppr-widget-gcode", ["chilipeppr_ready", "waypoints",
                 pauseOnM6: pauseOnM6,
                 sendOnM6: sendOnM6,
                 sendOffM6: sendOffM6,
+                probeCmd: probeCmd,
                 showBody: showBody,
                 preUpload: preUpload,
                 multiLineMode: multiLineMode,
@@ -922,7 +926,7 @@ cpdefine("inline:com-chilipeppr-widget-gcode", ["chilipeppr_ready", "waypoints",
                 chilipeppr.publish('/com-chilipeppr-interface-cnccontroller/unEnergizeMotors', "");
             });
             $('.com-chilipeppr-widget-gcode-toolchange-probe').click(function() {
-                chilipeppr.publish("/com-chilipeppr-widget-serialport/send", 'G28.2 Z0\n');
+                chilipeppr.publish("/com-chilipeppr-widget-serialport/send", that.options.probeCmd + '\n');
             });
             $('.com-chilipeppr-widget-gcode-toolchange-sendgcode').click(function() {
                 chilipeppr.publish("/com-chilipeppr-widget-serialport/send", that.toolChangeRepositionCmd + '\n');
@@ -3647,7 +3651,7 @@ cpdefine("inline:com-chilipeppr-widget-gcode", ["chilipeppr_ready", "waypoints",
                 <button class="btn btn-xs btn-default com-chilipeppr-widget-gcode-toolchange-unenergize" xstyle="width:100%;">Motors Previous Setting <span class="com-chilipeppr-widget-gcode-toolchange-motorsprev"></span></button>
                 <button class="btn btn-xs btn-default com-chilipeppr-widget-gcode-toolchange-spindlestop" xstyle="width:100%;">Stop Spindle (M5)</button>
                 <button class="btn btn-xs btn-default com-chilipeppr-widget-gcode-toolchange-spindlestart" xstyle="width:100%;">Start Spindle (M3)</button>
-                <button class="btn btn-xs btn-default com-chilipeppr-widget-gcode-toolchange-probe" xstyle="width:100%;">Run Probe to Zero Out Z Axis (G28.2 Z0)</button>
+                <button class="btn btn-xs btn-default com-chilipeppr-widget-gcode-toolchange-probe" xstyle="width:100%;">Run Probe Command</button>
                 <button class="btn btn-xs btn-default com-chilipeppr-widget-gcode-toolchange-g43" xstyle="width:100%;">Send "<span id="com-chilipeppr-widget-gcode-g43-cmd">G43 T-</span>"</button>
                 <button class="btn btn-xs btn-default com-chilipeppr-widget-gcode-toolchange-sendgcode" xstyle="width:100%;">Send Reposition "<span class="com-chilipeppr-widget-gcode-toolchange-cmd">G0 X- Y- Z-</span>"</button>
             </div>
@@ -3973,7 +3977,10 @@ cpdefine("inline:com-chilipeppr-widget-gcode", ["chilipeppr_ready", "waypoints",
                         <div class="input-group" style="width:300px;">
                             <textarea class="form-control" id="com-chilipeppr-widget-gcode-option-sendoffM6" placeholder="Gcode"></textarea>
                         </div>
-                     
+                         <p style="padding-top:6px;">Definition of G-code to send as probe command in tool change dialog:</p>
+                        <div class="input-group" style="width:300px;">
+                            <textarea class="form-control" id="com-chilipeppr-widget-gcode-option-probe-cmd" placeholder="Gcode"></textarea>
+                        </div>
 
                         <p class="options-heading" style="padding-top:16px;">Pre-Process Gcode</p>
 

--- a/widget.html
+++ b/widget.html
@@ -99,7 +99,7 @@
                 <button class="btn btn-xs btn-default com-chilipeppr-widget-gcode-toolchange-unenergize" xstyle="width:100%;">Motors Previous Setting <span class="com-chilipeppr-widget-gcode-toolchange-motorsprev"></span></button>
                 <button class="btn btn-xs btn-default com-chilipeppr-widget-gcode-toolchange-spindlestop" xstyle="width:100%;">Stop Spindle (M5)</button>
                 <button class="btn btn-xs btn-default com-chilipeppr-widget-gcode-toolchange-spindlestart" xstyle="width:100%;">Start Spindle (M3)</button>
-                <button class="btn btn-xs btn-default com-chilipeppr-widget-gcode-toolchange-probe" xstyle="width:100%;">Run Probe to Zero Out Z Axis (G28.2 Z0)</button>
+                <button class="btn btn-xs btn-default com-chilipeppr-widget-gcode-toolchange-probe" xstyle="width:100%;">Run Probe Command</button>
                 <button class="btn btn-xs btn-default com-chilipeppr-widget-gcode-toolchange-g43" xstyle="width:100%;">Send "<span id="com-chilipeppr-widget-gcode-g43-cmd">G43 T-</span>"</button>
                 <button class="btn btn-xs btn-default com-chilipeppr-widget-gcode-toolchange-sendgcode" xstyle="width:100%;">Send Reposition "<span class="com-chilipeppr-widget-gcode-toolchange-cmd">G0 X- Y- Z-</span>"</button>
             </div>
@@ -425,7 +425,10 @@
                         <div class="input-group" style="width:300px;">
                             <textarea class="form-control" id="com-chilipeppr-widget-gcode-option-sendoffM6" placeholder="Gcode"></textarea>
                         </div>
-                     
+                         <p style="padding-top:6px;">Definition of G-code to send as probe command in tool change dialog:</p>
+                        <div class="input-group" style="width:300px;">
+                            <textarea class="form-control" id="com-chilipeppr-widget-gcode-option-probe-cmd" placeholder="Gcode"></textarea>
+                        </div>
 
                         <p class="options-heading" style="padding-top:16px;">Pre-Process Gcode</p>
 

--- a/widget.html
+++ b/widget.html
@@ -427,7 +427,7 @@
                         </div>
                          <p style="padding-top:6px;">Definition of G-code to send as probe command in tool change dialog:</p>
                         <div class="input-group" style="width:300px;">
-                            <textarea class="form-control" id="com-chilipeppr-widget-gcode-option-probe-cmd" placeholder="Gcode"></textarea>
+                            <textarea class="form-control" id="com-chilipeppr-widget-gcode-option-probe-cmd" placeholder="Gcode">G28.2 Z0</textarea>
                         </div>
 
                         <p class="options-heading" style="padding-top:16px;">Pre-Process Gcode</p>

--- a/widget.js
+++ b/widget.js
@@ -423,9 +423,19 @@ cpdefine("inline:com-chilipeppr-widget-gcode", ["chilipeppr_ready", "waypoints",
                     if (!('addlinenums' in options))
                         options.addlinenums = true;
                 }
+                // Default new options for backwards compatibility
+                if (!('sendOnM6' in options)) {
+                    options.sendOnM6 = "";
+                }
+                if (!('sendOffM6' in options)) {
+                    options.sendOffM6 = "";
+                }
+                if (!('probeCmd' in options)) {
+                    options.probeCmd = "G28.2 Z0";
+                }
                 
             } else {
-                options = {whenPlay: "serial", perRow: "3d", perRow3dType: "goto", delayPerLine: this.delayPerLine, pauseOnM6: true, preUpload: 'none', multiLineMode: 'yes', multiLines: 50, ppsOnPlayFlush: false, ppsOnStopFeedhold: false, ppsOnPauseFeedhold: false, ppsOnUnpauseResume: false, removeemptylines: true, addlinenums: true};
+                options = {whenPlay: "serial", perRow: "3d", perRow3dType: "goto", delayPerLine: this.delayPerLine, pauseOnM6: true, preUpload: 'none', multiLineMode: 'yes', multiLines: 50, ppsOnPlayFlush: false, ppsOnStopFeedhold: false, ppsOnPauseFeedhold: false, ppsOnUnpauseResume: false, removeemptylines: true, addlinenums: true, sendOnM6: "", sendOffM6: "", probeCmd: "G28.2 Z0"};
             }
             this.options = options;
             console.log("options:", options);

--- a/widget.js
+++ b/widget.js
@@ -450,6 +450,7 @@ cpdefine("inline:com-chilipeppr-widget-gcode", ["chilipeppr_ready", "waypoints",
             }
             $('#com-chilipeppr-widget-gcode-option-sendonM6').val(this.options.sendOnM6);
             $('#com-chilipeppr-widget-gcode-option-sendoffM6').val(this.options.sendOffM6);
+            $('#com-chilipeppr-widget-gcode-option-probe-cmd').val(this.options.probeCmd);
 
             if (this.options.preUpload) {
                 var opt = ["none", "100", "1000", "10000", "20000"];
@@ -541,7 +542,7 @@ cpdefine("inline:com-chilipeppr-widget-gcode", ["chilipeppr_ready", "waypoints",
             var that = this;
             console.log("saveOptionsModal");
 
-            var whenPlay, perRow, perRow3dType, delayPerLine, pauseOnM6, sendOnM6, sendOffM6, showBody, preUpload, multiLineMode, multiLines, ppsOnPlayFlush, ppsOnStopFeedhold, ppsOnPauseFeedhold, ppsOnUnpauseResume, removeemptylines, addlinenums;
+            var whenPlay, perRow, perRow3dType, delayPerLine, pauseOnM6, sendOnM6, sendOffM6, probeCmd, showBody, preUpload, multiLineMode, multiLines, ppsOnPlayFlush, ppsOnStopFeedhold, ppsOnPauseFeedhold, ppsOnUnpauseResume, removeemptylines, addlinenums;
             if ($('#com-chilipeppr-widget-gcode-option-whenplay-serial').is(':checked'))
                 whenPlay = "serial";
             else if ($('#com-chilipeppr-widget-gcode-option-whenplay-3d').is(':checked'))
@@ -560,6 +561,8 @@ cpdefine("inline:com-chilipeppr-widget-gcode", ["chilipeppr_ready", "waypoints",
                 pauseOnM6 = false;
             sendOnM6 = $('#com-chilipeppr-widget-gcode-option-sendonM6').val();
             sendOffM6 = $('#com-chilipeppr-widget-gcode-option-sendoffM6').val();
+            probeCmd = $('#com-chilipeppr-widget-gcode-option-probe-cmd').val();
+        
             if ($('#com-chilipeppr-widget-gcode-option-removeemptylines').is(':checked'))
                 removeemptylines = true;
             else
@@ -602,6 +605,7 @@ cpdefine("inline:com-chilipeppr-widget-gcode", ["chilipeppr_ready", "waypoints",
                 pauseOnM6: pauseOnM6,
                 sendOnM6: sendOnM6,
                 sendOffM6: sendOffM6,
+                probeCmd: probeCmd,
                 showBody: showBody,
                 preUpload: preUpload,
                 multiLineMode: multiLineMode,
@@ -658,7 +662,7 @@ cpdefine("inline:com-chilipeppr-widget-gcode", ["chilipeppr_ready", "waypoints",
                 chilipeppr.publish('/com-chilipeppr-interface-cnccontroller/unEnergizeMotors', "");
             });
             $('.com-chilipeppr-widget-gcode-toolchange-probe').click(function() {
-                chilipeppr.publish("/com-chilipeppr-widget-serialport/send", 'G28.2 Z0\n');
+                chilipeppr.publish("/com-chilipeppr-widget-serialport/send", that.options.probeCmd + '\n');
             });
             $('.com-chilipeppr-widget-gcode-toolchange-sendgcode').click(function() {
                 chilipeppr.publish("/com-chilipeppr-widget-serialport/send", that.toolChangeRepositionCmd + '\n');


### PR DESCRIPTION
Made the command issued by the "probe" button in the tool change dialog customizable rather than hardcoded to "g28.2 z0".

Depending on how your machine is set up, probing towards zero might not be the correct thing to do, and you might also want to do a two-stage quick and then slow probe.
