### PR TITLE
Tool change related bug fixes.

### DIFF
--- a/auto-generated-widget.html
+++ b/auto-generated-widget.html
@@ -993,7 +993,8 @@ cpdefine("inline:com-chilipeppr-widget-gcode", ["chilipeppr_ready", "waypoints",
                     }
                     this.toolChangeRepositionCmd = this.toolChangeRepositionCmd + " G0 X" + pos.x + " Y" + pos.y + " Z" + pos.z;
                     
-                    $('.com-chilipeppr-widget-gcode-toolchange-cmd').text(this.toolChangeRepositionCmd);
+                    $('.com-chilipeppr-widget-gcode-toolchange-reposition1').text(this.toolChangeRepositionCmd);
+                    $('.com-chilipeppr-widget-gcode-toolchange-reposition2').text(this.toolChangeRepositionCmd);
 
                     // Send gcode if defined
                     var sendOnM6 = $('#com-chilipeppr-widget-gcode-option-sendonM6').val();
@@ -2897,13 +2898,13 @@ cpdefine("inline:com-chilipeppr-widget-gcode", ["chilipeppr_ready", "waypoints",
             // just ignore it. Need to do this before setting
             // isInExecuteScrollToMode below or we'll think that we
             // need to handle events we don't
+            var item = data;
             if ('line' in item && item.line < 1) return;
             
             // make sure we're in onExecuted mode
             var wasInExecuteScrollToMode = this.isInExecuteScrollToMode;
             this.isInExecuteScrollToMode = true;
             
-            var item = data;
             var msgEl;
             // check that id string is not null/empty and starts with
             // a g, cuz we make all our id's start with g
@@ -3640,7 +3641,7 @@ cpdefine("inline:com-chilipeppr-widget-gcode", ["chilipeppr_ready", "waypoints",
         <div class="alert alert-info alert-dismissible com-chilipeppr-widget-gcode-toolchange hidden" role="alert" style="margin:0;border-radius:0;">
             <button type="button" class="close" xdata-dismiss="alert"><span aria-hidden="true">&times;</span><span class="sr-only">Close</span></button>
             <p style="font-size:smaller;padding-bottom:6px;">You are in tool change mode. Change to tool <b><span id="com-chilipeppr-widget-gcode-toolnumber1">T??</span></b>. You may jog to move the tool around and/or reset your Z zero position. Put your motors at full power if you don't want them to move while you change your tool. Make sure to issue the following Gcode to get back
-                to the position just prior to your tool change "<span class="com-chilipeppr-widget-gcode-toolchange-cmd">G0 X? Y? Z?</span>".
+                to the position just prior to your tool change "<span class="com-chilipeppr-widget-gcode-toolchange-reposition1">G0 X? Y? Z?</span>".
             </p>
             <div class="btn-group-vertical">
                 <button class="btn btn-xs btn-default com-chilipeppr-widget-gcode-toolchange-energize" xstyle="width:100%;">Motors Full Power</button>
@@ -3649,7 +3650,7 @@ cpdefine("inline:com-chilipeppr-widget-gcode", ["chilipeppr_ready", "waypoints",
                 <button class="btn btn-xs btn-default com-chilipeppr-widget-gcode-toolchange-spindlestart" xstyle="width:100%;">Start Spindle (M3)</button>
                 <button class="btn btn-xs btn-default com-chilipeppr-widget-gcode-toolchange-probe" xstyle="width:100%;">Run Probe to Zero Out Z Axis (G28.2 Z0)</button>
                 <button class="btn btn-xs btn-default com-chilipeppr-widget-gcode-toolchange-g43" xstyle="width:100%;">Send "<span id="com-chilipeppr-widget-gcode-g43-cmd">G43 T-</span>"</button>
-                <button class="btn btn-xs btn-default com-chilipeppr-widget-gcode-toolchange-sendgcode" xstyle="width:100%;">Send Reposition "<span class="com-chilipeppr-widget-gcode-toolchange-cmd">G0 X- Y- Z-</span>"</button>
+                <button class="btn btn-xs btn-default com-chilipeppr-widget-gcode-toolchange-sendgcode" xstyle="width:100%;">Send Reposition "<span class="com-chilipeppr-widget-gcode-toolchange-reposition2">G0 X- Y- Z-</span>"</button>
             </div>
         </div>
         <div id="com-chilipeppr-widget-gcode-body-wrapper">

--- a/widget.html
+++ b/widget.html
@@ -92,7 +92,7 @@
         <div class="alert alert-info alert-dismissible com-chilipeppr-widget-gcode-toolchange hidden" role="alert" style="margin:0;border-radius:0;">
             <button type="button" class="close" xdata-dismiss="alert"><span aria-hidden="true">&times;</span><span class="sr-only">Close</span></button>
             <p style="font-size:smaller;padding-bottom:6px;">You are in tool change mode. Change to tool <b><span id="com-chilipeppr-widget-gcode-toolnumber1">T??</span></b>. You may jog to move the tool around and/or reset your Z zero position. Put your motors at full power if you don't want them to move while you change your tool. Make sure to issue the following Gcode to get back
-                to the position just prior to your tool change "<span class="com-chilipeppr-widget-gcode-toolchange-cmd">G0 X? Y? Z?</span>".
+                to the position just prior to your tool change "<span class="com-chilipeppr-widget-gcode-toolchange-reposition1">G0 X? Y? Z?</span>".
             </p>
             <div class="btn-group-vertical">
                 <button class="btn btn-xs btn-default com-chilipeppr-widget-gcode-toolchange-energize" xstyle="width:100%;">Motors Full Power</button>
@@ -101,7 +101,7 @@
                 <button class="btn btn-xs btn-default com-chilipeppr-widget-gcode-toolchange-spindlestart" xstyle="width:100%;">Start Spindle (M3)</button>
                 <button class="btn btn-xs btn-default com-chilipeppr-widget-gcode-toolchange-probe" xstyle="width:100%;">Run Probe to Zero Out Z Axis (G28.2 Z0)</button>
                 <button class="btn btn-xs btn-default com-chilipeppr-widget-gcode-toolchange-g43" xstyle="width:100%;">Send "<span id="com-chilipeppr-widget-gcode-g43-cmd">G43 T-</span>"</button>
-                <button class="btn btn-xs btn-default com-chilipeppr-widget-gcode-toolchange-sendgcode" xstyle="width:100%;">Send Reposition "<span class="com-chilipeppr-widget-gcode-toolchange-cmd">G0 X- Y- Z-</span>"</button>
+                <button class="btn btn-xs btn-default com-chilipeppr-widget-gcode-toolchange-sendgcode" xstyle="width:100%;">Send Reposition "<span class="com-chilipeppr-widget-gcode-toolchange-reposition2">G0 X- Y- Z-</span>"</button>
             </div>
         </div>
         <div id="com-chilipeppr-widget-gcode-body-wrapper">

--- a/widget.js
+++ b/widget.js
@@ -729,7 +729,8 @@ cpdefine("inline:com-chilipeppr-widget-gcode", ["chilipeppr_ready", "waypoints",
                     }
                     this.toolChangeRepositionCmd = this.toolChangeRepositionCmd + " G0 X" + pos.x + " Y" + pos.y + " Z" + pos.z;
                     
-                    $('.com-chilipeppr-widget-gcode-toolchange-cmd').text(this.toolChangeRepositionCmd);
+                    $('.com-chilipeppr-widget-gcode-toolchange-reposition1').text(this.toolChangeRepositionCmd);
+                    $('.com-chilipeppr-widget-gcode-toolchange-reposition2').text(this.toolChangeRepositionCmd);
 
                     // Send gcode if defined
                     var sendOnM6 = $('#com-chilipeppr-widget-gcode-option-sendonM6').val();
@@ -2633,13 +2634,13 @@ cpdefine("inline:com-chilipeppr-widget-gcode", ["chilipeppr_ready", "waypoints",
             // just ignore it. Need to do this before setting
             // isInExecuteScrollToMode below or we'll think that we
             // need to handle events we don't
+            var item = data;
             if ('line' in item && item.line < 1) return;
             
             // make sure we're in onExecuted mode
             var wasInExecuteScrollToMode = this.isInExecuteScrollToMode;
             this.isInExecuteScrollToMode = true;
             
-            var item = data;
             var msgEl;
             // check that id string is not null/empty and starts with
             // a g, cuz we make all our id's start with g


### PR DESCRIPTION
Fix two bugs:
- in onExecute, "item" was used before being defined. Not sure how this worked...
- fix duplicate naming of the two elements showing the command to go back to the pre-toolchange position.
