### PR TITLE
Hopefully final fix for tracking which lines have been displayed.

### DIFF
--- a/auto-generated-widget.html
+++ b/auto-generated-widget.html
@@ -472,14 +472,14 @@ cpdefine("inline:com-chilipeppr-widget-gcode", ["chilipeppr_ready", "waypoints",
         },
         fileLines: [], // contains the gcode file as array per line
         metaLines: [], // stores meta data related to each line in fileLines
-        metaObj: {
+        metaObj: { // Default meta data object
+	    isSent: false,
             isQueued: false,
             isWritten: false,
-            isCompleted: false,
+            isCompleted: false, // whether onComplete has processed it
             isError: false,
-            isExecuted: false,
-            isWillGetExecuted: false, // whether this type of line gets executed
-            id: null
+            isExecuted: false, // whether onExecute has processed it
+	    isDisplayed: false // whether onComplete or onExecute has reacted to it
         },
         linesComplete: [],
         linesToShow: 50, // how many lines to show in the infinite scroll area
@@ -956,29 +956,34 @@ cpdefine("inline:com-chilipeppr-widget-gcode", ["chilipeppr_ready", "waypoints",
 
         },
         isInToolChangeMode: false, // track whether we're showing tool change div
-        toolNumber: null, // tool number to show in tool change div
         toolChangeRepositionCmd: null, // gcode to reposition to prior location before tool change (in case they jog)
         toolChangeCmd: null, // G43 command to change tool length offset
-        showToolChangeModal: function() {
-            console.log("Switching to tool ",this.toolNumber);
-            if (!this.toolNumber)
+        showToolChangeModal: function(linegcode, source) {
+
+	    var toolNumber = linegcode.match(/T\d+/ig)[0]
+            console.log("Switching to tool ",toolNumber);
+            if (!toolNumber)
             {
-                this.toolNumber = "Unknown Tool";
+                toolNumber = "Unknown Tool";
                 this.toolChangeCmd = "G49";
             }
             else
             {
-                this.toolChangeCmd = "G43 " + this.toolNumber.replace("T","H");
+                this.toolChangeCmd = "G43 " + toolNumber.replace("T","H");
             }
-            $('#com-chilipeppr-widget-gcode-toolnumber1').text(this.toolNumber);
-            $('#com-chilipeppr-widget-gcode-toolnumber2').text(this.toolNumber);
+            $('#com-chilipeppr-widget-gcode-toolnumber1').text(toolNumber);
+            $('#com-chilipeppr-widget-gcode-toolnumber2').text(toolNumber);
             $('#com-chilipeppr-widget-gcode-g43-cmd').text(this.toolChangeCmd);
             
 
             if ($('#com-chilipeppr-widget-gcode-option-pauseOnM6').is(':checked'))
                 $('#com-chilipeppr-widget-gcode-option-pauseOnM6-alt').prop('checked', true);
             else
-                $('#com-chilipeppr-widget-gcode-option-pauseOnM6-alt').prop('checked', false);
+                $('#com-chilipeppr-widget-gcode-option-pauseOnM6-alt').prop('checked',false);
+
+	    if (false)
+		$('#com-chilipeppr-widget-gcode-toolchange-debug').text("Source: " +source);
+	    
             $('#com-chilipeppr-widget-gcode-toolchange-modal').modal('show');
 
             // setup div in main widget for when modal dismisses
@@ -1696,12 +1701,7 @@ cpdefine("inline:com-chilipeppr-widget-gcode", ["chilipeppr_ready", "waypoints",
             for (; indx < this.metaLines.length; indx++) {
                 if (that.metaLines[indx] != null) {
                     console.log("found metaLine. resetting. indx:", indx);
-                    that.metaLines[indx].isSent = false;
-                    that.metaLines[indx].isQueued = false;
-                    that.metaLines[indx].isWritten = false;
-                    that.metaLines[indx].isCompleted = false;
-                    that.metaLines[indx].isError = false;
-                    that.metaLines[indx].isExecuted = false;
+		    that.metaLines[indx] = $.extend({}, that.metaObj);
                     // this will update the UI, but only for showing lines
                     that.updateRowQueueStats(indx + 1);
                 }
@@ -2084,11 +2084,10 @@ cpdefine("inline:com-chilipeppr-widget-gcode", ["chilipeppr_ready", "waypoints",
                 // yes, it's m6
                 // see if they want pause
                 if (this.options.pauseOnM6) {
-                    this.toolNumber = linegcode.match(/T\d+/ig)[0];
                     this.gotoLine(this.currentLine, true);
                     // pass a null event, but true for the isFromM6 parameter
                     this.onPause(null, true);
-                    //this.showToolChangeModal();
+                    //this.showToolChangeModal(linegcode,"onplay");
                     // sync gcode list view
                     //if (!this.isPlayNextLineNoScroll)
                     // dont' go to next line, just return
@@ -2628,7 +2627,7 @@ cpdefine("inline:com-chilipeppr-widget-gcode", ["chilipeppr_ready", "waypoints",
                     // update meta data
                     if (this.metaLines[idnum - 1] == null) {
                         //console.log("no meta data for this element yet. creating it.");
-                        this.metaLines[idnum - 1] = { isSent: true };
+                        this.metaLines[idnum - 1] = $.extend({}, this.metaObj);
                     }
                     
                     // set that it is queued
@@ -2667,7 +2666,7 @@ cpdefine("inline:com-chilipeppr-widget-gcode", ["chilipeppr_ready", "waypoints",
                 // update meta data
                 if (this.metaLines[idnum - 1] == null) {
                     //console.log("onQueue. no meta data for this element yet. creating it.");
-                    this.metaLines[idnum - 1] = { isQueued: true };
+                    this.metaLines[idnum - 1] = $.extend({}, this.metaObj);
                 }
 
                 // set that it is queued
@@ -2704,7 +2703,7 @@ cpdefine("inline:com-chilipeppr-widget-gcode", ["chilipeppr_ready", "waypoints",
                 // update meta data
                 if (this.metaLines[idnum - 1] == null) {
                     //console.log("no meta data for this element yet. creating it.");
-                    this.metaLines[idnum - 1] = { isWritten: true };
+                    this.metaLines[idnum - 1] = $.extend({}, this.metaObj);
                 }
 
                 // set that it is queued
@@ -2718,6 +2717,37 @@ cpdefine("inline:com-chilipeppr-widget-gcode", ["chilipeppr_ready", "waypoints",
             }
             //console.groupEnd();
         },
+	displayLine: function(index, chilipepprPauseFun) {
+	    // Only do this if not done already
+            if (this.metaLines[index].isDisplayed)
+		return;
+
+	    this.metaLines[index].isDisplayed = true;			
+	    
+            // see if comment
+            var linegcode = this.fileLines[index];
+            if (linegcode.match(/(\(.*\)|;.*$)/)) {
+                // it's comment
+                //var re = /\((.*)\)/;
+                //re.exec(linegcode);
+                var comment = RegExp.$1;
+                console.log("Found comment:", comment);
+                chilipeppr.publish("/com-chilipeppr-elem-flashmsg/flashmsg", "Gcode Comment", comment, 3000, true);
+            }
+                    
+            // see if M6 tool change command & user wants to pause on M6
+            if (linegcode.match(/M0?6/i) && this.options.pauseOnM6) {
+                this.showToolChangeModal(linegcode,
+					 String(index)+" "+JSON.stringify(this.metaLines[index]));
+            }
+                    
+            // see if chilipeppr_pause command
+            if (linegcode.match(/chilipeppr_pause/i)) {
+                chilipepprPauseFun(
+                    { line: index + 1, gcode: linegcode } 
+                );
+            }
+	},	    
         onComplete: function(data) {
             // write it to the log
             //console.group("gcode widget - onComplete");
@@ -2740,7 +2770,7 @@ cpdefine("inline:com-chilipeppr-widget-gcode", ["chilipeppr_ready", "waypoints",
                 // update meta data
                 if (this.metaLines[idnum - 1] == null) {
                     //console.log("no meta data for this element yet. creating it.");
-                    this.metaLines[idnum - 1] = { isCompleted: true };
+                    this.metaLines[idnum - 1] = $.extend({}, this.metaObj);
                 }
 
                 // set that it is queued
@@ -2752,32 +2782,13 @@ cpdefine("inline:com-chilipeppr-widget-gcode", ["chilipeppr_ready", "waypoints",
                 this.updateRowQueueStats(idnum);
                 
                 // let user follow along on completes
-                if (!this.isInExecuteScrollToMode) {
+		
+                if (!this.isInExecuteScrollToMode &&
+		    !this.metaLines[idnum - 1].isDisplayed) {
+
                     this.gotoLine(idnum, true);
-                    
-                    // see if comment
-                    var linegcode = this.fileLines[idnum -1];
-                    if (linegcode.match(/(\(.*\)|;.*$)/)) {
-                        // it's comment
-                        //var re = /\((.*)\)/;
-                        //re.exec(linegcode);
-                        var comment = RegExp.$1;
-                        console.log("Found comment:", comment);
-                        chilipeppr.publish("/com-chilipeppr-elem-flashmsg/flashmsg", "Gcode Comment", comment, 3000, true);
-                    }
-                    
-                    // see if M6 tool change command & user wants to pause on M6
-                    if (linegcode.match(/M0?6/i) && this.options.pauseOnM6) {
-                        this.toolNumber = linegcode.match(/T\d+/ig)[0];
-                        this.showToolChangeModal();
-                    }
-                    
-                    // see if chilipeppr_pause command
-                    if (linegcode.match(/chilipeppr_pause/i)) {
-                        this.onChiliPepprPauseOnComplete(
-                            { line: idnum, gcode: linegcode } 
-                        );
-                    }
+
+                    this.displayLine(idnum - 1, this.onChiliPepprPauseOnComplete);
 
                     // see if we're done sending
                     if (idnum >= this.fileLines.length) {
@@ -2828,7 +2839,7 @@ cpdefine("inline:com-chilipeppr-widget-gcode", ["chilipeppr_ready", "waypoints",
                 // update meta data
                 if (this.metaLines[idnum - 1] == null) {
                     //console.log("no meta data for this element yet. creating it.");
-                    this.metaLines[idnum - 1] = { isError: true };
+                    this.metaLines[idnum - 1] = $.extend({}, this.metaObj);
                 }
 
                 // set that it is error
@@ -2857,8 +2868,7 @@ cpdefine("inline:com-chilipeppr-widget-gcode", ["chilipeppr_ready", "waypoints",
                     // see if M6 tool change command & user wants to pause on M6
                     //(just because controller errored out, user is still expecting a pause on M6 from the software)
                     if (linegcode.match(/M0?6/i) && this.options.pauseOnM6) {
-                        this.toolNumber = linegcode.match(/T\d+/ig)[0];
-                        this.showToolChangeModal();
+                        this.showToolChangeModal(linegcode, "onerror");
                     }
 
                     // see if we're done sending
@@ -2916,7 +2926,6 @@ cpdefine("inline:com-chilipeppr-widget-gcode", ["chilipeppr_ready", "waypoints",
             if ('line' in item && item.line < 1) return;
             
             // make sure we're in onExecuted mode
-            var wasInExecuteScrollToMode = this.isInExecuteScrollToMode;
             this.isInExecuteScrollToMode = true;
             
             var msgEl;
@@ -2938,7 +2947,7 @@ cpdefine("inline:com-chilipeppr-widget-gcode", ["chilipeppr_ready", "waypoints",
                     //console.log("onExecute. marking metaline as executed. markIndex:", markIndex, "metaLine:", this.metaLines[markIndex]);
                     if (this.metaLines[markIndex] == null) {
                         //console.log("onExecute no meta data for this element yet. creating it.");
-                        this.metaLines[markIndex] = { isExecuted: true };
+                        this.metaLines[markIndex] = $.extend({}, this.metaObj);
                     }
                     
                     // set that it is queued
@@ -2948,57 +2957,14 @@ cpdefine("inline:com-chilipeppr-widget-gcode", ["chilipeppr_ready", "waypoints",
                     // send in 1-based number, not 0-based
                     // our id is 1-based, i.e. the row number
                     this.updateRowQueueStats(markIndex + 1);
-                    
-                    // Only do this is we were inExecuteScrollToMode
-                    // before, otherwise onComplete has done it
-                    // already.
-                    if (wasInExecuteScrollToMode ||
-                        !this.metaLines[markIndex].isCompleted)
-                    {
-                        // this code really should be in a function since
-                        // onComplete does the same thing
-                        
-                        // see if comment
-                        var linegcode = this.fileLines[markIndex];
-                        if (linegcode.match(/(\(.*\)|;.*$)/)) {
-                            // it's comment
-                            //var re = /\((.*)\)/;
-                            //re.exec(linegcode);
-                            var comment = RegExp.$1;
-                            //console.log("onExecute. Found comment:", comment);
-                            chilipeppr.publish("/com-chilipeppr-elem-flashmsg/flashmsg", "Gcode Comment", comment, 3000, true);
-                        }
-                    
-                        // see if M6 tool change command & user wants to pause on M6
-                        if (linegcode.match(/M0?6/i) && this.options.pauseOnM6) {
-                            this.toolNumber = linegcode.match(/T\d+/ig)[0];
-                            this.showToolChangeModal();
-                        }
-                    
-                        // see if chilipeppr_pause command
-                        if (linegcode.match(/chilipeppr_pause/i)) {
-                            this.onChiliPepprPauseOnExecute(
-                                { line: markIndex + 1, gcode: linegcode } 
-                            );
-                        }
-                    }
+
+		    // Act on line, if applicable
+                    this.displayLine(markIndex, this.onChiliPepprPauseOnExecute);
+
                     //console.log("metaLine after:", this.metaLines[markIndex]);
                 }
                 this.lastLineMarkedExecuted = markIndex;
-                
-                /*
-                // update meta data
-                if (this.metaLines[idnum - 1] == null) {
-                    //console.log("onExecute no meta data for this element yet. creating it.");
-                    this.metaLines[idnum - 1] = { isExecuted: true };
-                }
 
-                // set that it is queued
-                this.metaLines[idnum - 1].isExecuted = true;
-                */
-                
-                
-                
                 // let user follow along on completes
                 this.gotoLine(idnum, true);
                 
@@ -4049,6 +4015,7 @@ cpdefine("inline:com-chilipeppr-widget-gcode", ["chilipeppr_ready", "waypoints",
                             <br/>(Can be changed later in options dialog for Gcode Widget)</input>
                         </label>
                     </div>
+                    <span id="com-chilipeppr-widget-gcode-toolchange-debug"></span>
 
                 </div>
                 <div class="modal-footer">

--- a/widget.html
+++ b/widget.html
@@ -486,6 +486,7 @@
                             <br/>(Can be changed later in options dialog for Gcode Widget)</input>
                         </label>
                     </div>
+                    <span id="com-chilipeppr-widget-gcode-toolchange-debug"></span>
 
                 </div>
                 <div class="modal-footer">

--- a/widget.js
+++ b/widget.js
@@ -208,14 +208,14 @@ cpdefine("inline:com-chilipeppr-widget-gcode", ["chilipeppr_ready", "waypoints",
         },
         fileLines: [], // contains the gcode file as array per line
         metaLines: [], // stores meta data related to each line in fileLines
-        metaObj: {
+        metaObj: { // Default meta data object
+	    isSent: false,
             isQueued: false,
             isWritten: false,
-            isCompleted: false,
+            isCompleted: false, // whether onComplete has processed it
             isError: false,
-            isExecuted: false,
-            isWillGetExecuted: false, // whether this type of line gets executed
-            id: null
+            isExecuted: false, // whether onExecute has processed it
+	    isDisplayed: false // whether onComplete or onExecute has reacted to it
         },
         linesComplete: [],
         linesToShow: 50, // how many lines to show in the infinite scroll area
@@ -692,29 +692,34 @@ cpdefine("inline:com-chilipeppr-widget-gcode", ["chilipeppr_ready", "waypoints",
 
         },
         isInToolChangeMode: false, // track whether we're showing tool change div
-        toolNumber: null, // tool number to show in tool change div
         toolChangeRepositionCmd: null, // gcode to reposition to prior location before tool change (in case they jog)
         toolChangeCmd: null, // G43 command to change tool length offset
-        showToolChangeModal: function() {
-            console.log("Switching to tool ",this.toolNumber);
-            if (!this.toolNumber)
+        showToolChangeModal: function(linegcode, source) {
+
+	    var toolNumber = linegcode.match(/T\d+/ig)[0]
+            console.log("Switching to tool ",toolNumber);
+            if (!toolNumber)
             {
-                this.toolNumber = "Unknown Tool";
+                toolNumber = "Unknown Tool";
                 this.toolChangeCmd = "G49";
             }
             else
             {
-                this.toolChangeCmd = "G43 " + this.toolNumber.replace("T","H");
+                this.toolChangeCmd = "G43 " + toolNumber.replace("T","H");
             }
-            $('#com-chilipeppr-widget-gcode-toolnumber1').text(this.toolNumber);
-            $('#com-chilipeppr-widget-gcode-toolnumber2').text(this.toolNumber);
+            $('#com-chilipeppr-widget-gcode-toolnumber1').text(toolNumber);
+            $('#com-chilipeppr-widget-gcode-toolnumber2').text(toolNumber);
             $('#com-chilipeppr-widget-gcode-g43-cmd').text(this.toolChangeCmd);
             
 
             if ($('#com-chilipeppr-widget-gcode-option-pauseOnM6').is(':checked'))
                 $('#com-chilipeppr-widget-gcode-option-pauseOnM6-alt').prop('checked', true);
             else
-                $('#com-chilipeppr-widget-gcode-option-pauseOnM6-alt').prop('checked', false);
+                $('#com-chilipeppr-widget-gcode-option-pauseOnM6-alt').prop('checked',false);
+
+	    if (false)
+		$('#com-chilipeppr-widget-gcode-toolchange-debug').text("Source: " +source);
+	    
             $('#com-chilipeppr-widget-gcode-toolchange-modal').modal('show');
 
             // setup div in main widget for when modal dismisses
@@ -1432,12 +1437,7 @@ cpdefine("inline:com-chilipeppr-widget-gcode", ["chilipeppr_ready", "waypoints",
             for (; indx < this.metaLines.length; indx++) {
                 if (that.metaLines[indx] != null) {
                     console.log("found metaLine. resetting. indx:", indx);
-                    that.metaLines[indx].isSent = false;
-                    that.metaLines[indx].isQueued = false;
-                    that.metaLines[indx].isWritten = false;
-                    that.metaLines[indx].isCompleted = false;
-                    that.metaLines[indx].isError = false;
-                    that.metaLines[indx].isExecuted = false;
+		    that.metaLines[indx] = $.extend({}, that.metaObj);
                     // this will update the UI, but only for showing lines
                     that.updateRowQueueStats(indx + 1);
                 }
@@ -1820,11 +1820,10 @@ cpdefine("inline:com-chilipeppr-widget-gcode", ["chilipeppr_ready", "waypoints",
                 // yes, it's m6
                 // see if they want pause
                 if (this.options.pauseOnM6) {
-                    this.toolNumber = linegcode.match(/T\d+/ig)[0];
                     this.gotoLine(this.currentLine, true);
                     // pass a null event, but true for the isFromM6 parameter
                     this.onPause(null, true);
-                    //this.showToolChangeModal();
+                    //this.showToolChangeModal(linegcode,"onplay");
                     // sync gcode list view
                     //if (!this.isPlayNextLineNoScroll)
                     // dont' go to next line, just return
@@ -2364,7 +2363,7 @@ cpdefine("inline:com-chilipeppr-widget-gcode", ["chilipeppr_ready", "waypoints",
                     // update meta data
                     if (this.metaLines[idnum - 1] == null) {
                         //console.log("no meta data for this element yet. creating it.");
-                        this.metaLines[idnum - 1] = { isSent: true };
+                        this.metaLines[idnum - 1] = $.extend({}, this.metaObj);
                     }
                     
                     // set that it is queued
@@ -2403,7 +2402,7 @@ cpdefine("inline:com-chilipeppr-widget-gcode", ["chilipeppr_ready", "waypoints",
                 // update meta data
                 if (this.metaLines[idnum - 1] == null) {
                     //console.log("onQueue. no meta data for this element yet. creating it.");
-                    this.metaLines[idnum - 1] = { isQueued: true };
+                    this.metaLines[idnum - 1] = $.extend({}, this.metaObj);
                 }
 
                 // set that it is queued
@@ -2440,7 +2439,7 @@ cpdefine("inline:com-chilipeppr-widget-gcode", ["chilipeppr_ready", "waypoints",
                 // update meta data
                 if (this.metaLines[idnum - 1] == null) {
                     //console.log("no meta data for this element yet. creating it.");
-                    this.metaLines[idnum - 1] = { isWritten: true };
+                    this.metaLines[idnum - 1] = $.extend({}, this.metaObj);
                 }
 
                 // set that it is queued
@@ -2454,6 +2453,37 @@ cpdefine("inline:com-chilipeppr-widget-gcode", ["chilipeppr_ready", "waypoints",
             }
             //console.groupEnd();
         },
+	displayLine: function(index, chilipepprPauseFun) {
+	    // Only do this if not done already
+            if (this.metaLines[index].isDisplayed)
+		return;
+
+	    this.metaLines[index].isDisplayed = true;			
+	    
+            // see if comment
+            var linegcode = this.fileLines[index];
+            if (linegcode.match(/(\(.*\)|;.*$)/)) {
+                // it's comment
+                //var re = /\((.*)\)/;
+                //re.exec(linegcode);
+                var comment = RegExp.$1;
+                console.log("Found comment:", comment);
+                chilipeppr.publish("/com-chilipeppr-elem-flashmsg/flashmsg", "Gcode Comment", comment, 3000, true);
+            }
+                    
+            // see if M6 tool change command & user wants to pause on M6
+            if (linegcode.match(/M0?6/i) && this.options.pauseOnM6) {
+                this.showToolChangeModal(linegcode,
+					 String(index)+" "+JSON.stringify(this.metaLines[index]));
+            }
+                    
+            // see if chilipeppr_pause command
+            if (linegcode.match(/chilipeppr_pause/i)) {
+                chilipepprPauseFun(
+                    { line: index + 1, gcode: linegcode } 
+                );
+            }
+	},	    
         onComplete: function(data) {
             // write it to the log
             //console.group("gcode widget - onComplete");
@@ -2476,7 +2506,7 @@ cpdefine("inline:com-chilipeppr-widget-gcode", ["chilipeppr_ready", "waypoints",
                 // update meta data
                 if (this.metaLines[idnum - 1] == null) {
                     //console.log("no meta data for this element yet. creating it.");
-                    this.metaLines[idnum - 1] = { isCompleted: true };
+                    this.metaLines[idnum - 1] = $.extend({}, this.metaObj);
                 }
 
                 // set that it is queued
@@ -2488,32 +2518,13 @@ cpdefine("inline:com-chilipeppr-widget-gcode", ["chilipeppr_ready", "waypoints",
                 this.updateRowQueueStats(idnum);
                 
                 // let user follow along on completes
-                if (!this.isInExecuteScrollToMode) {
+		
+                if (!this.isInExecuteScrollToMode &&
+		    !this.metaLines[idnum - 1].isDisplayed) {
+
                     this.gotoLine(idnum, true);
-                    
-                    // see if comment
-                    var linegcode = this.fileLines[idnum -1];
-                    if (linegcode.match(/(\(.*\)|;.*$)/)) {
-                        // it's comment
-                        //var re = /\((.*)\)/;
-                        //re.exec(linegcode);
-                        var comment = RegExp.$1;
-                        console.log("Found comment:", comment);
-                        chilipeppr.publish("/com-chilipeppr-elem-flashmsg/flashmsg", "Gcode Comment", comment, 3000, true);
-                    }
-                    
-                    // see if M6 tool change command & user wants to pause on M6
-                    if (linegcode.match(/M0?6/i) && this.options.pauseOnM6) {
-                        this.toolNumber = linegcode.match(/T\d+/ig)[0];
-                        this.showToolChangeModal();
-                    }
-                    
-                    // see if chilipeppr_pause command
-                    if (linegcode.match(/chilipeppr_pause/i)) {
-                        this.onChiliPepprPauseOnComplete(
-                            { line: idnum, gcode: linegcode } 
-                        );
-                    }
+
+                    this.displayLine(idnum - 1, this.onChiliPepprPauseOnComplete);
 
                     // see if we're done sending
                     if (idnum >= this.fileLines.length) {
@@ -2564,7 +2575,7 @@ cpdefine("inline:com-chilipeppr-widget-gcode", ["chilipeppr_ready", "waypoints",
                 // update meta data
                 if (this.metaLines[idnum - 1] == null) {
                     //console.log("no meta data for this element yet. creating it.");
-                    this.metaLines[idnum - 1] = { isError: true };
+                    this.metaLines[idnum - 1] = $.extend({}, this.metaObj);
                 }
 
                 // set that it is error
@@ -2593,8 +2604,7 @@ cpdefine("inline:com-chilipeppr-widget-gcode", ["chilipeppr_ready", "waypoints",
                     // see if M6 tool change command & user wants to pause on M6
                     //(just because controller errored out, user is still expecting a pause on M6 from the software)
                     if (linegcode.match(/M0?6/i) && this.options.pauseOnM6) {
-                        this.toolNumber = linegcode.match(/T\d+/ig)[0];
-                        this.showToolChangeModal();
+                        this.showToolChangeModal(linegcode, "onerror");
                     }
 
                     // see if we're done sending
@@ -2652,7 +2662,6 @@ cpdefine("inline:com-chilipeppr-widget-gcode", ["chilipeppr_ready", "waypoints",
             if ('line' in item && item.line < 1) return;
             
             // make sure we're in onExecuted mode
-            var wasInExecuteScrollToMode = this.isInExecuteScrollToMode;
             this.isInExecuteScrollToMode = true;
             
             var msgEl;
@@ -2674,7 +2683,7 @@ cpdefine("inline:com-chilipeppr-widget-gcode", ["chilipeppr_ready", "waypoints",
                     //console.log("onExecute. marking metaline as executed. markIndex:", markIndex, "metaLine:", this.metaLines[markIndex]);
                     if (this.metaLines[markIndex] == null) {
                         //console.log("onExecute no meta data for this element yet. creating it.");
-                        this.metaLines[markIndex] = { isExecuted: true };
+                        this.metaLines[markIndex] = $.extend({}, this.metaObj);
                     }
                     
                     // set that it is queued
@@ -2684,57 +2693,14 @@ cpdefine("inline:com-chilipeppr-widget-gcode", ["chilipeppr_ready", "waypoints",
                     // send in 1-based number, not 0-based
                     // our id is 1-based, i.e. the row number
                     this.updateRowQueueStats(markIndex + 1);
-                    
-                    // Only do this is we were inExecuteScrollToMode
-                    // before, otherwise onComplete has done it
-                    // already.
-                    if (wasInExecuteScrollToMode ||
-                        !this.metaLines[markIndex].isCompleted)
-                    {
-                        // this code really should be in a function since
-                        // onComplete does the same thing
-                        
-                        // see if comment
-                        var linegcode = this.fileLines[markIndex];
-                        if (linegcode.match(/(\(.*\)|;.*$)/)) {
-                            // it's comment
-                            //var re = /\((.*)\)/;
-                            //re.exec(linegcode);
-                            var comment = RegExp.$1;
-                            //console.log("onExecute. Found comment:", comment);
-                            chilipeppr.publish("/com-chilipeppr-elem-flashmsg/flashmsg", "Gcode Comment", comment, 3000, true);
-                        }
-                    
-                        // see if M6 tool change command & user wants to pause on M6
-                        if (linegcode.match(/M0?6/i) && this.options.pauseOnM6) {
-                            this.toolNumber = linegcode.match(/T\d+/ig)[0];
-                            this.showToolChangeModal();
-                        }
-                    
-                        // see if chilipeppr_pause command
-                        if (linegcode.match(/chilipeppr_pause/i)) {
-                            this.onChiliPepprPauseOnExecute(
-                                { line: markIndex + 1, gcode: linegcode } 
-                            );
-                        }
-                    }
+
+		    // Act on line, if applicable
+                    this.displayLine(markIndex, this.onChiliPepprPauseOnExecute);
+
                     //console.log("metaLine after:", this.metaLines[markIndex]);
                 }
                 this.lastLineMarkedExecuted = markIndex;
-                
-                /*
-                // update meta data
-                if (this.metaLines[idnum - 1] == null) {
-                    //console.log("onExecute no meta data for this element yet. creating it.");
-                    this.metaLines[idnum - 1] = { isExecuted: true };
-                }
 
-                // set that it is queued
-                this.metaLines[idnum - 1].isExecuted = true;
-                */
-                
-                
-                
                 // let user follow along on completes
                 this.gotoLine(idnum, true);
                 


### PR DESCRIPTION
Ok, more...

The tracking of what had been done with oncomplete vs onExecute was still not reliable. It appeared the onExecutes could run several stages behind the onCompletes, so even after getting the first onExecute, there could be more lines that had already been acted on.

Instead of using the lastLineExecuted, I'm now explicitly tracking whether a line has been processed, either by onComplete or onExecute, with a new "isDisplayed" tag in metaLines. This appears to be reliable **as long as** the number of multi-lines is less than the line number of the first M6 line. If it is equal or greater to it, when you hit play it will immediately go into a pause **without** displaying the M6 dialog. I tried debugging but again it doesn't happen if the console is open. Any idea how it could go into a pause without triggering the dialog?

I got a bit more invasive and cleaned up some duplicated code between the two functions, too.

Let me know if you have issues with any of the changes.
