### PR TITLE
Second try at header stabilization

### DIFF
--- a/auto-generated-widget.html
+++ b/auto-generated-widget.html
@@ -3866,8 +3866,8 @@ cpdefine("inline:com-chilipeppr-widget-gcode", ["chilipeppr_ready", "waypoints",
                         <!--<li><a href="" class="standalone" target="_blank">View Widget Standalone</a></li>-->
                         <!--<li><a href="" class="fork" target="_blank">Fork Widget</a></li>-->
                     </ul>
-
                 </div>
+
             </div>
             <div id="com-chilipeppr-widget-gcode-feedrate" class="hidden" style="padding-top:5px;overflow:hidden;">
                 <div class="input-group input-group-sm" style=" "> <span class="input-group-btn ">
@@ -3880,9 +3880,9 @@ cpdefine("inline:com-chilipeppr-widget-gcode", ["chilipeppr_ready", "waypoints",
                     </button>
                     <button class="btn btn-default btn-xs" id="com-chilipeppr-widget-gcode-feedrate-reset" type="button">Reset</button>
                     </span>
-
                 </div>
             </div>
+
         </div>
         <div class="alert alert-info alert-dismissible com-chilipeppr-widget-gcode-toolchange hidden" role="alert" style="margin:0;border-radius:0;">
             <button type="button" class="close" xdata-dismiss="alert"><span aria-hidden="true">&times;</span><span class="sr-only">Close</span></button>

--- a/auto-generated-widget.html
+++ b/auto-generated-widget.html
@@ -3866,6 +3866,7 @@ cpdefine("inline:com-chilipeppr-widget-gcode", ["chilipeppr_ready", "waypoints",
                         <!--<li><a href="" class="standalone" target="_blank">View Widget Standalone</a></li>-->
                         <!--<li><a href="" class="fork" target="_blank">Fork Widget</a></li>-->
                     </ul>
+
                 </div>
             </div>
             <div id="com-chilipeppr-widget-gcode-feedrate" class="hidden" style="padding-top:5px;overflow:hidden;">
@@ -3879,6 +3880,7 @@ cpdefine("inline:com-chilipeppr-widget-gcode", ["chilipeppr_ready", "waypoints",
                     </button>
                     <button class="btn btn-default btn-xs" id="com-chilipeppr-widget-gcode-feedrate-reset" type="button">Reset</button>
                     </span>
+
                 </div>
             </div>
         </div>

--- a/auto-generated-widget.html
+++ b/auto-generated-widget.html
@@ -3806,45 +3806,52 @@ cpdefine("inline:com-chilipeppr-widget-gcode", ["chilipeppr_ready", "waypoints",
     <!--Put HTML Contents of Widget Here-->
     <div id="com-chilipeppr-widget-gcodeviewer" class="panel panel-default com-chilipeppr-widget-gcode ">
         <div class="panel-heading">
-            <div class="" style="padding-bottom:10px;"><span class="panel-title">Gcode</span>
-                <span class="btn-groupplannerpause" data-toggle="popover" data-content="Sending is paused to prevent buffer overflow.">
+            <div class="pull-left">
+                <span class="panel-title">Gcode</span>
+                <div class="btn-groupplannerpause pull-right" data-toggle="popover" data-content="Sending is paused to prevent buffer overflow.">
                     <span disabled="true" class="plannerpauseindicator glyphicon glyphicon glyphicon-time btn btn-sm"></span>
-                </span>
-<div class="btn-toolbar" role="toolbar" style="position:absolute;right:0px;top:0px;padding:10px 15px;">
-                <div class="btn-group" style="margin-left:0px;">
-                    <button type="button" id="com-chilipeppr-widget-gcode-play" class="btn btn-default btn-xs"><span class="glyphicon glyphicon-play"></span>
-
-                    </button>
-                    <button type="button" id="com-chilipeppr-widget-gcode-pause" disabled class="btn btn-default btn-xs"><span class="glyphicon glyphicon-pause"></span>
-
-                    </button>
-                    <button type="button" id="com-chilipeppr-widget-gcode-stop" disabled class="btn btn-default btn-xs"><span class="glyphicon glyphicon-stop"></span>
-
-                    </button>
-                    <button type="button" id="com-chilipeppr-widget-gcode-stepback" class="btn btn-default btn-xs"><span class="glyphicon glyphicon-step-backward"></span>
-
-                    </button>
-                    <button type="button" id="com-chilipeppr-widget-gcode-stepfwd" class="btn btn-default btn-xs"><span class="glyphicon glyphicon-step-forward"></span></button>
-                    <button type="button" id="com-chilipeppr-widget-gcode-jumptoline" class="btn btn-default btn-xs"><span class="glyphicon glyphicon-plane"></span></button>
-
-                    <button type="button" id="com-chilipeppr-widget-gcode-btnoptions" class="btn btn-default btn-xs"><span class="glyphicon glyphicon-cog"></span></button>
                 </div>
-                <div class="btn-group">
-                    <button type="button" class="btn btn-xs btn-default hidebody"><span class="glyphicon glyphicon-chevron-up"></span></button>
-                </div>
-
-                <div class="btn-group">
-                    <button type="button" class="btn btn-xs btn-default dropdown-toggle" data-toggle="dropdown"> <span class="caret"></span>
-
+            </div>
+            <div class="btn-toolbar" role="toolbar">
+                <div class="btn-group pull-right">
+                    <button type="button" class="btn btn-xs btn-default dropdown-toggle" data-toggle="dropdown">
+                        <span class="caret"></span>
                     </button>
                     <ul class="dropdown-menu dropdown-menu-right pubsub-dropdown-menu" role="menu">
                         <!-- <li role="presentation" class="dropdown-header fork-name"></li>
-                    <li><a href="" class="standalone" target="_blank">View Widget Standalone</a></li>
-                    <li><a href="" class="fork" target="_blank">Fork Widget</a></li> -->
+                        <li><a href="" class="standalone" target="_blank">View Widget Standalone</a></li>
+                        <li><a href="" class="fork" target="_blank">Fork Widget</a></li> -->
                     </ul>
                 </div>
+                <div class="btn-group pull-right">
+                    <button type="button" class="btn btn-xs btn-default hidebody">
+                        <span class="glyphicon glyphicon-chevron-up"></span>
+                    </button>
+                </div>
+                <div class="btn-group pull-center" style="margin-right:10px;">
+                    <button type="button" id="com-chilipeppr-widget-gcode-play" class="btn btn-default btn-xs">
+                        <span class="glyphicon glyphicon-play"></span>
+                    </button>
+                    <button type="button" id="com-chilipeppr-widget-gcode-pause" disabled class="btn btn-default btn-xs">
+                        <span class="glyphicon glyphicon-pause"></span>
+                    </button>
+                    <button type="button" id="com-chilipeppr-widget-gcode-stop" disabled class="btn btn-default btn-xs">
+                        <span class="glyphicon glyphicon-stop"></span>
+                    </button>
+                    <button type="button" id="com-chilipeppr-widget-gcode-stepback" class="btn btn-default btn-xs">
+                        <span class="glyphicon glyphicon-step-backward"></span>
+                    </button>
+                    <button type="button" id="com-chilipeppr-widget-gcode-stepfwd" class="btn btn-default btn-xs">
+                        <span class="glyphicon glyphicon-step-forward"></span>
+                    </button>
+                    <button type="button" id="com-chilipeppr-widget-gcode-jumptoline" class="btn btn-default btn-xs">
+                        <span class="glyphicon glyphicon-plane"></span>
+                    </button>
+                    <button type="button" id="com-chilipeppr-widget-gcode-btnoptions" class="btn btn-default btn-xs">
+                        <span class="glyphicon glyphicon-cog"></span>
+                    </button>
+                </div>
             </div>
-</div>
             <div>
                 <button type="button" id="" class="btn btn-default btn-xs com-chilipeppr-widget-gcode-showfr">
                     Feed Rate Override
@@ -3860,7 +3867,6 @@ cpdefine("inline:com-chilipeppr-widget-gcode", ["chilipeppr_ready", "waypoints",
                         <!--<li><a href="" class="fork" target="_blank">Fork Widget</a></li>-->
                     </ul>
                 </div>
-
             </div>
             <div id="com-chilipeppr-widget-gcode-feedrate" class="hidden" style="padding-top:5px;overflow:hidden;">
                 <div class="input-group input-group-sm" style=" "> <span class="input-group-btn ">
@@ -3875,7 +3881,6 @@ cpdefine("inline:com-chilipeppr-widget-gcode", ["chilipeppr_ready", "waypoints",
                     </span>
                 </div>
             </div>
-
         </div>
         <div class="alert alert-info alert-dismissible com-chilipeppr-widget-gcode-toolchange hidden" role="alert" style="margin:0;border-radius:0;">
             <button type="button" class="close" xdata-dismiss="alert"><span aria-hidden="true">&times;</span><span class="sr-only">Close</span></button>

--- a/auto-generated-widget.html
+++ b/auto-generated-widget.html
@@ -3810,6 +3810,7 @@ cpdefine("inline:com-chilipeppr-widget-gcode", ["chilipeppr_ready", "waypoints",
                 <span class="btn-groupplannerpause" data-toggle="popover" data-content="Sending is paused to prevent buffer overflow.">
                     <span disabled="true" class="plannerpauseindicator glyphicon glyphicon glyphicon-time btn btn-sm"></span>
                 </span>
+<div class="btn-toolbar" role="toolbar" style="position:absolute;right:0px;top:0px;padding:10px 15px;">
                 <div class="btn-group" style="margin-left:0px;">
                     <button type="button" id="com-chilipeppr-widget-gcode-play" class="btn btn-default btn-xs"><span class="glyphicon glyphicon-play"></span>
 
@@ -3843,6 +3844,7 @@ cpdefine("inline:com-chilipeppr-widget-gcode", ["chilipeppr_ready", "waypoints",
                     </ul>
                 </div>
             </div>
+</div>
             <div>
                 <button type="button" id="" class="btn btn-default btn-xs com-chilipeppr-widget-gcode-showfr">
                     Feed Rate Override

--- a/widget.html
+++ b/widget.html
@@ -96,8 +96,8 @@
                         <!--<li><a href="" class="standalone" target="_blank">View Widget Standalone</a></li>-->
                         <!--<li><a href="" class="fork" target="_blank">Fork Widget</a></li>-->
                     </ul>
-
                 </div>
+
             </div>
             <div id="com-chilipeppr-widget-gcode-feedrate" class="hidden" style="padding-top:5px;overflow:hidden;">
                 <div class="input-group input-group-sm" style=" "> <span class="input-group-btn ">
@@ -110,9 +110,9 @@
                     </button>
                     <button class="btn btn-default btn-xs" id="com-chilipeppr-widget-gcode-feedrate-reset" type="button">Reset</button>
                     </span>
-
                 </div>
             </div>
+
         </div>
         <div class="alert alert-info alert-dismissible com-chilipeppr-widget-gcode-toolchange hidden" role="alert" style="margin:0;border-radius:0;">
             <button type="button" class="close" xdata-dismiss="alert"><span aria-hidden="true">&times;</span><span class="sr-only">Close</span></button>

--- a/widget.html
+++ b/widget.html
@@ -36,45 +36,52 @@
     <!--Put HTML Contents of Widget Here-->
     <div id="com-chilipeppr-widget-gcodeviewer" class="panel panel-default com-chilipeppr-widget-gcode ">
         <div class="panel-heading">
-            <div class="" style="padding-bottom:10px;"><span class="panel-title">Gcode</span>
-                <span class="btn-groupplannerpause" data-toggle="popover" data-content="Sending is paused to prevent buffer overflow.">
+            <div class="pull-left">
+                <span class="panel-title">Gcode</span>
+                <div class="btn-groupplannerpause pull-right" data-toggle="popover" data-content="Sending is paused to prevent buffer overflow.">
                     <span disabled="true" class="plannerpauseindicator glyphicon glyphicon glyphicon-time btn btn-sm"></span>
-                </span>
-<div class="btn-toolbar" role="toolbar" style="position:absolute;right:0px;top:0px;padding:10px 15px;">
-                <div class="btn-group" style="margin-left:0px;">
-                    <button type="button" id="com-chilipeppr-widget-gcode-play" class="btn btn-default btn-xs"><span class="glyphicon glyphicon-play"></span>
-
-                    </button>
-                    <button type="button" id="com-chilipeppr-widget-gcode-pause" disabled class="btn btn-default btn-xs"><span class="glyphicon glyphicon-pause"></span>
-
-                    </button>
-                    <button type="button" id="com-chilipeppr-widget-gcode-stop" disabled class="btn btn-default btn-xs"><span class="glyphicon glyphicon-stop"></span>
-
-                    </button>
-                    <button type="button" id="com-chilipeppr-widget-gcode-stepback" class="btn btn-default btn-xs"><span class="glyphicon glyphicon-step-backward"></span>
-
-                    </button>
-                    <button type="button" id="com-chilipeppr-widget-gcode-stepfwd" class="btn btn-default btn-xs"><span class="glyphicon glyphicon-step-forward"></span></button>
-                    <button type="button" id="com-chilipeppr-widget-gcode-jumptoline" class="btn btn-default btn-xs"><span class="glyphicon glyphicon-plane"></span></button>
-
-                    <button type="button" id="com-chilipeppr-widget-gcode-btnoptions" class="btn btn-default btn-xs"><span class="glyphicon glyphicon-cog"></span></button>
                 </div>
-                <div class="btn-group">
-                    <button type="button" class="btn btn-xs btn-default hidebody"><span class="glyphicon glyphicon-chevron-up"></span></button>
-                </div>
-
-                <div class="btn-group">
-                    <button type="button" class="btn btn-xs btn-default dropdown-toggle" data-toggle="dropdown"> <span class="caret"></span>
-
+            </div>
+            <div class="btn-toolbar" role="toolbar">
+                <div class="btn-group pull-right">
+                    <button type="button" class="btn btn-xs btn-default dropdown-toggle" data-toggle="dropdown">
+                        <span class="caret"></span>
                     </button>
                     <ul class="dropdown-menu dropdown-menu-right pubsub-dropdown-menu" role="menu">
                         <!-- <li role="presentation" class="dropdown-header fork-name"></li>
-                    <li><a href="" class="standalone" target="_blank">View Widget Standalone</a></li>
-                    <li><a href="" class="fork" target="_blank">Fork Widget</a></li> -->
+                        <li><a href="" class="standalone" target="_blank">View Widget Standalone</a></li>
+                        <li><a href="" class="fork" target="_blank">Fork Widget</a></li> -->
                     </ul>
                 </div>
+                <div class="btn-group pull-right">
+                    <button type="button" class="btn btn-xs btn-default hidebody">
+                        <span class="glyphicon glyphicon-chevron-up"></span>
+                    </button>
+                </div>
+                <div class="btn-group pull-center" style="margin-right:10px;">
+                    <button type="button" id="com-chilipeppr-widget-gcode-play" class="btn btn-default btn-xs">
+                        <span class="glyphicon glyphicon-play"></span>
+                    </button>
+                    <button type="button" id="com-chilipeppr-widget-gcode-pause" disabled class="btn btn-default btn-xs">
+                        <span class="glyphicon glyphicon-pause"></span>
+                    </button>
+                    <button type="button" id="com-chilipeppr-widget-gcode-stop" disabled class="btn btn-default btn-xs">
+                        <span class="glyphicon glyphicon-stop"></span>
+                    </button>
+                    <button type="button" id="com-chilipeppr-widget-gcode-stepback" class="btn btn-default btn-xs">
+                        <span class="glyphicon glyphicon-step-backward"></span>
+                    </button>
+                    <button type="button" id="com-chilipeppr-widget-gcode-stepfwd" class="btn btn-default btn-xs">
+                        <span class="glyphicon glyphicon-step-forward"></span>
+                    </button>
+                    <button type="button" id="com-chilipeppr-widget-gcode-jumptoline" class="btn btn-default btn-xs">
+                        <span class="glyphicon glyphicon-plane"></span>
+                    </button>
+                    <button type="button" id="com-chilipeppr-widget-gcode-btnoptions" class="btn btn-default btn-xs">
+                        <span class="glyphicon glyphicon-cog"></span>
+                    </button>
+                </div>
             </div>
-</div>
             <div>
                 <button type="button" id="" class="btn btn-default btn-xs com-chilipeppr-widget-gcode-showfr">
                     Feed Rate Override
@@ -90,7 +97,6 @@
                         <!--<li><a href="" class="fork" target="_blank">Fork Widget</a></li>-->
                     </ul>
                 </div>
-
             </div>
             <div id="com-chilipeppr-widget-gcode-feedrate" class="hidden" style="padding-top:5px;overflow:hidden;">
                 <div class="input-group input-group-sm" style=" "> <span class="input-group-btn ">
@@ -105,7 +111,6 @@
                     </span>
                 </div>
             </div>
-
         </div>
         <div class="alert alert-info alert-dismissible com-chilipeppr-widget-gcode-toolchange hidden" role="alert" style="margin:0;border-radius:0;">
             <button type="button" class="close" xdata-dismiss="alert"><span aria-hidden="true">&times;</span><span class="sr-only">Close</span></button>

--- a/widget.html
+++ b/widget.html
@@ -40,6 +40,7 @@
                 <span class="btn-groupplannerpause" data-toggle="popover" data-content="Sending is paused to prevent buffer overflow.">
                     <span disabled="true" class="plannerpauseindicator glyphicon glyphicon glyphicon-time btn btn-sm"></span>
                 </span>
+<div class="btn-toolbar" role="toolbar" style="position:absolute;right:0px;top:0px;padding:10px 15px;">
                 <div class="btn-group" style="margin-left:0px;">
                     <button type="button" id="com-chilipeppr-widget-gcode-play" class="btn btn-default btn-xs"><span class="glyphicon glyphicon-play"></span>
 
@@ -73,6 +74,7 @@
                     </ul>
                 </div>
             </div>
+</div>
             <div>
                 <button type="button" id="" class="btn btn-default btn-xs com-chilipeppr-widget-gcode-showfr">
                     Feed Rate Override

--- a/widget.html
+++ b/widget.html
@@ -96,6 +96,7 @@
                         <!--<li><a href="" class="standalone" target="_blank">View Widget Standalone</a></li>-->
                         <!--<li><a href="" class="fork" target="_blank">Fork Widget</a></li>-->
                     </ul>
+
                 </div>
             </div>
             <div id="com-chilipeppr-widget-gcode-feedrate" class="hidden" style="padding-top:5px;overflow:hidden;">
@@ -109,6 +110,7 @@
                     </button>
                     <button class="btn btn-default btn-xs" id="com-chilipeppr-widget-gcode-feedrate-reset" type="button">Reset</button>
                     </span>
+
                 </div>
             </div>
         </div>


### PR DESCRIPTION
This version uses pull-right and pull-center decorations on <div> to accomplish the task, instead of <span>.  The buttons reposition themselves even more pleasantly than before.  I have not experienced any instances of incorrect panel positions.

I did see strange behavior from a Cloud 9 live preview in a case where widget.html had been modified but not saved.  It seemed that the live update got confused.  Saving the file and reloading cleared up the problem.  I have not seen any problems when loading a properly-saved file.

In this version, I dispensed with the attempt to create a minimal-visual-diff patch.  Instead, I used strict and consistent indentation for all elements inside the affected code, making is easier to verify the containment hierarchy.